### PR TITLE
Fix display of all images by reconfiguring file-loader.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = [
       rules: [
         { test: /\.jsx?$/, exclude: /node_modules.*\.js/, loader: 'babel-loader' },
         { test: /\.s(a|c)ss$/, exclude: /node_modules.*\.js/, loader: 'style-loader!css-loader!postcss-loader!fast-sass-loader' },
-        { test: /\.(gif|svg|png|jpe?g)$/, loader: 'file-loader?name=images/[hash].[ext]!img-loader' }
+        { test: /\.(gif|svg|png|jpe?g)$/, loader: 'file-loader?name=images/[hash].[ext]!img-loader', options: {esModule: false}}
       ]
     },
     plugins: [


### PR DESCRIPTION
As all the image links are currently broken (the point to "[object Module]"), this patch configures file-loader to workaround that:

https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module